### PR TITLE
[FIXED] -- Fix typo in value error message for missing billing email …

### DIFF
--- a/src/pay_ccavenue/ccavenue.py
+++ b/src/pay_ccavenue/ccavenue.py
@@ -223,7 +223,7 @@ class CCAvenue:
             self.__form_data["billing_email"] is None
             or isinstance(self.__form_data["billing_email"], str) is False
         ):
-            raise ValueError("You must provide a billing tel for CCAvenue.")
+            raise ValueError("You must provide a billing email for CCAvenue.")
 
     def parse_request_body(self, request_body: dict) -> str:
         """


### PR DESCRIPTION
1. Previously, the error message incorrectly referred to 'billing tel' instead of 'billing email' when raising a ValueError for missing billing email in CCAvenue integration.
2. This commit corrects the typo in the error message to ensure accuracy and clarity for developers encountering this issue.
3. Now, the error message accurately states that a billing email must be provided for CCAvenue transactions.
<img width="533" alt="ss_ccavenue_pay_python_typo_error_email" src="https://github.com/kdpisda/python-pay-ccavenue/assets/53856555/46cd8c74-db96-4bc5-b5fc-2d5c63eeeaee">

